### PR TITLE
Allow Access to WP-Admin and Login Page During Maintenance Mode

### DIFF
--- a/pressable-maintenance-mode.php
+++ b/pressable-maintenance-mode.php
@@ -20,6 +20,10 @@ if ( 'cli' == php_sapi_name() ) {
 
 // Activate WordPress Maintenance Mode
 function wp_maintenance_mode() {
+    // Exit if requesting an administration or login page
+    if ( is_admin() || strpos($_SERVER['REQUEST_URI'], 'wp-login.php') !== false ) {
+      return;
+  }
     // If the current user does not have the capability to edit themes or is not logged in.
     if ( !current_user_can( 'edit_themes' ) || ! is_user_logged_in() ) {
         // Send a raw HTTP header to control the cache settings for the response being sent back to the client/browser

--- a/pressable-maintenance-mode.php
+++ b/pressable-maintenance-mode.php
@@ -24,6 +24,7 @@ function wp_maintenance_mode() {
     if ( is_admin() || strpos($_SERVER['REQUEST_URI'], 'wp-login.php') !== false ) {
       return;
     }
+    
     // If the current user does not have the capability to edit themes or is not logged in.
     if ( !current_user_can( 'edit_themes' ) || ! is_user_logged_in() ) {
         // Send a raw HTTP header to control the cache settings for the response being sent back to the client/browser

--- a/pressable-maintenance-mode.php
+++ b/pressable-maintenance-mode.php
@@ -4,7 +4,7 @@ Plugin Name: Maintenance Mode
 Plugin URI: https://github.com/pressable/pressable-maintenance-mode
 Description: Effortlessly enable maintenance mode on your website! When activated, non-logged-in visitors or users without editing privileges are greeted with a stylish, user-friendly notice indicating that the website is undergoing maintenance.
 Author: Pressable
-Version: 1.0.4
+Version: 1.0.5
 Author URI: https://pressable.com/
 License: GPL2
 */

--- a/pressable-maintenance-mode.php
+++ b/pressable-maintenance-mode.php
@@ -23,7 +23,7 @@ function wp_maintenance_mode() {
     // Exit if requesting an administration or login page
     if ( is_admin() || strpos($_SERVER['REQUEST_URI'], 'wp-login.php') !== false ) {
       return;
-  }
+    }
     // If the current user does not have the capability to edit themes or is not logged in.
     if ( !current_user_can( 'edit_themes' ) || ! is_user_logged_in() ) {
         // Send a raw HTTP header to control the cache settings for the response being sent back to the client/browser


### PR DESCRIPTION
This update allows users to navigate to `/wp-admin` (or whatever the path may be as long is it returns `is_admin()`) and the `wp-login.php` page while Maintenance Mode is active.  Once logged in, the user can make changes  and access settings `/wp-admin` 

`is_admin()` doesn't check for capabilities, instead, it determines whether the current request is for an administrative interface page. An unauthenticated user would then be redirected to wp-login.php.

This was requested as some users activated Maintenance Mode while being logged out and couldn't log in to /wp-admin without deactivating the plugin.

#### Testing

* Activate plugin
* Navigate to the home page, should see the maintenance mode message
* Navigate to /wp-admin and /wp-login.php, should be accessible and display log in form
* Bonus: Create a subscriber user, log in, and confirm it cannot access the site

