### PR TITLE
CSS Fix, Add Title, and Move HTTP 503 Response to wp_die

### DIFF
--- a/pressable-maintenance-mode.php
+++ b/pressable-maintenance-mode.php
@@ -171,7 +171,7 @@ function wp_maintenance_mode() {
                     </svg>
                 </div>
             </div>
-        </div>'
+        </div>',
         'Maintenance Mode', // Custom title for wp_die page
         array('response' => 503) // Set HTTP response to 503, informing the client that service is temporarily unavailable. Commonly used in maintenance modes to notify users and search engines that the downtime is temporary.
       );

--- a/pressable-maintenance-mode.php
+++ b/pressable-maintenance-mode.php
@@ -41,13 +41,6 @@ function wp_maintenance_mode() {
         // it's often used as an extra measure to prevent caching in older clients.
         header( "Pragma: no-cache" );
 
-        // Set the HTTP response status code to 503 - Service Unavailable.
-        // This informs clients that the server is temporarily unable to handle the request,
-        // which is commonly used during maintenance mode or server downtime to notify both
-        // users and search engines that the unavailability is temporary.
-        http_response_code( 503 );
-
-
         wp_die('
         <style>
             #error-page {

--- a/pressable-maintenance-mode.php
+++ b/pressable-maintenance-mode.php
@@ -173,6 +173,7 @@ function wp_maintenance_mode() {
             </div>
         </div>'
         'Maintenance Mode', // Custom title for wp_die page
+        array('response' => 503) // Set HTTP response to 503, informing the client that service is temporarily unavailable. Commonly used in maintenance modes to notify users and search engines that the downtime is temporary.
       );
     }
 }

--- a/pressable-maintenance-mode.php
+++ b/pressable-maintenance-mode.php
@@ -41,8 +41,13 @@ function wp_maintenance_mode() {
         // it's often used as an extra measure to prevent caching in older clients.
         header( "Pragma: no-cache" );
 
-        wp_die('
-        <style>
+        wp_die(
+        '<style>
+            /* Remove body border set by WordPress core wp_die */
+            body {
+                border: none;
+            }
+            
             #error-page {
                 margin: 0 !important;
                 width: 100%;
@@ -166,8 +171,9 @@ function wp_maintenance_mode() {
                     </svg>
                 </div>
             </div>
-        </div>
-      ');
+        </div>'
+        'Maintenance Mode', // Custom title for wp_die page
+      );
     }
 }
 


### PR DESCRIPTION
Didn't set custom commit messages but added descriptions under each.

Here's a rundown of the changes.

* Adds CSS that removes body border set by WP core's wp_die rendering which looks odd and can cause overflow
* Adds a custom `Maintenance Mode` title to page, replacing the default `WordPress > Error`
* Removes `http_response_code( 503 );`, set 503 response via wp_die instead.

More on wp_die's title and response code support at https://developer.wordpress.org/reference/functions/wp_die/

### Testing

1. Install, activate
2. Check to ensure the rendered page includes a 503 response and a custom `Maintenance Mode` page title. 
3. No white body border should be present
4. Check for PHP errors

### Example of Issue

Without these changes, the page title is `WordPress > Error` and there is a white border present that causes overflow.

![Screen Shot on 2024-02-16 at 17:11:53](https://github.com/pressable/pressable-maintenance-mode/assets/4887830/b4de9ca2-4e6a-47e0-bdd7-c4fbc3fd075f)


